### PR TITLE
feat: add CLA document and org-wide workflow template

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,31 @@
+# Contributor License Agreement
+
+## ORGANVM Individual Contributor License Agreement v1.0
+
+Thank you for your interest in contributing to the ORGANVM project ecosystem. This Contributor License Agreement (CLA) clarifies the intellectual property license granted with contributions from any person or entity.
+
+By signing this CLA, you accept and agree to the following terms for your present and future contributions submitted to any repository within the ORGANVM ecosystem (organizations: `meta-organvm`, `organvm-i-theoria`, `organvm-ii-poiesis`, `organvm-iii-ergon`, `organvm-iv-taxis`, `organvm-v-logos`, `organvm-vi-koinonia`, `organvm-vii-kerygma`).
+
+## Terms
+
+1. **Definitions.** "You" means the individual signing this CLA. "Contribution" means any original work of authorship submitted by You to the project, including modifications or additions to existing work.
+
+2. **Grant of Copyright License.** You hereby grant to the project maintainers and to recipients of software distributed by the project a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute your Contributions and such derivative works.
+
+3. **Grant of Patent License.** You hereby grant to the project maintainers and to recipients of software distributed by the project a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Contribution, where such license applies only to those patent claims licensable by You that are necessarily infringed by your Contribution alone or by combination of your Contribution with the project to which it was submitted.
+
+4. **Original Work.** You represent that each of your Contributions is your original creation. You represent that your Contribution submissions include complete details of any third-party license or other restriction of which you are aware and which are associated with any part of your Contributions.
+
+5. **No Obligation.** You understand that the decision to include your Contribution in any project is entirely at the discretion of the project maintainers, and this agreement does not obligate the project to use your Contribution.
+
+6. **License Compatibility.** Contributions to repositories licensed under MIT, Apache 2.0, or CC BY-SA 4.0 are accepted under those respective licenses. Contributions to repositories with other licenses will be governed by the license stated in that repository's LICENSE file at the time of contribution.
+
+## How to Sign
+
+To sign this CLA, comment on your pull request with the following exact text:
+
+```
+I have read the CLA Document and I hereby sign the CLA
+```
+
+Your signature will be recorded automatically and applies to all future contributions to the ORGANVM ecosystem.

--- a/workflow-templates/cla.properties.json
+++ b/workflow-templates/cla.properties.json
@@ -1,0 +1,6 @@
+{
+  "name": "CLA Assistant",
+  "description": "Contributor License Agreement check for ORGANVM repos",
+  "iconName": "shield-check",
+  "categories": ["Automation"]
+}

--- a/workflow-templates/cla.yml
+++ b/workflow-templates/cla.yml
@@ -1,0 +1,36 @@
+name: CLA Assistant
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA Assistant
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/cla.json'
+          path-to-document: 'https://github.com/meta-organvm/.github/blob/main/CLA.md'
+          branch: 'main'
+          allowlist: 'bot*,dependabot[bot],github-actions[bot],4444J99'
+          custom-notsigned-prcomment: |
+            Thank you for your contribution! Before we can merge this PR, we need you to sign our [Contributor License Agreement](https://github.com/meta-organvm/.github/blob/main/CLA.md).
+
+            To sign, please comment on this PR with the following text:
+
+            > I have read the CLA Document and I hereby sign the CLA
+
+            This is a one-time requirement that covers all future contributions to the ORGANVM ecosystem.
+          custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'


### PR DESCRIPTION
## Summary
- Adds CLA.md — the ORGANVM Individual Contributor License Agreement v1.0
- Adds workflow-templates/cla.yml — reusable workflow template for all org repos
- Lightweight, contributor-friendly, stored-in-repo approach (no external service)

## Context
SOP--open-source-licensing-and-ip.md Phase III mandates CLA enforcement on all public repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)