### PR TITLE
feat: derive org profile from corpus projection (kill 113/404K drift)

### DIFF
--- a/.github/workflows/refresh-profile.yml
+++ b/.github/workflows/refresh-profile.yml
@@ -1,0 +1,43 @@
+name: Refresh Profile
+
+# The org profile is a projection of the corpus (which owns the organ taxonomy
+# and live metrics). Pull the rendered projection and commit it if it changed.
+# Pull model — no cross-org token needed (public raw URL), mirroring how the
+# portfolio fetches system-metrics.json at build time.
+
+on:
+  schedule:
+    - cron: '30 6 * * *'  # daily, just after the corpus metrics-refresh (06:00 UTC)
+  workflow_dispatch:
+  push:
+    paths:
+      - scripts/refresh-profile.py
+      - .github/workflows/refresh-profile.yml
+
+permissions:
+  contents: write
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Pull projected profile from corpus
+        run: python3 scripts/refresh-profile.py
+
+      - name: Commit if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet -- profile/README.md; then
+            echo "No profile changes"
+          else
+            git add profile/README.md
+            git commit -m "chore: refresh profile from corpus projection"
+            git push
+          fi

--- a/profile/README.md
+++ b/profile/README.md
@@ -2,144 +2,49 @@
 
 # meta-organvm
 
-_System-wide registry, governance rules, and cross-organ coordination_
-
 > *μετά (meta) — beyond, about, self-referential*
 
 **Eight organs. One system. Creative infrastructure at institutional scale.**
 
-[![Organ I — Theory](https://img.shields.io/badge/I-Theory-6A0DAD)](https://github.com/organvm-i-theoria)
-[![Organ II — Art](https://img.shields.io/badge/II-Art-DC143C)](https://github.com/organvm-ii-poiesis)
-[![Organ III — Commerce](https://img.shields.io/badge/III-Commerce-228B22)](https://github.com/organvm-iii-ergon)
-[![Organ IV — Orchestration](https://img.shields.io/badge/IV-Orchestration-FF8C00)](https://github.com/organvm-iv-taxis)
-[![Organ V — Public Process](https://img.shields.io/badge/V-Public%20Process-4169E1)](https://github.com/organvm-v-logos)
-[![Organ VI — Community](https://img.shields.io/badge/VI-Community-20B2AA)](https://github.com/organvm-vi-koinonia)
-[![Organ VII — Marketing](https://img.shields.io/badge/VII-Marketing-FF1493)](https://github.com/organvm-vii-kerygma)
-
-**171 repositories &bull; 988K+ words of documentation &bull; 10 GitHub organizations &bull; 65 published essays**
-
-**[Read the essays →](https://organvm-v-logos.github.io/public-process/)**
-
 </div>
 
 ---
 
-## System Overview
-
-The organvm system is a creative-institutional infrastructure composed of eight specialized organs — each operating as an independent GitHub organization with its own repositories, governance model, and domain focus. Together they span epistemological theory, generative art, commercial products, orchestration tooling, public scholarship, community spaces, and content distribution — realized across 10 GitHub organizations.
-
-This is not a monorepo. It is not a corporate org chart. It is an organism — a living system where theory feeds art, art feeds commerce, and the whole is governed by explicit dependency rules that prevent architectural decay. Each organ has a Greek name drawn from its domain's philosophical lineage, and each operates with the autonomy of an independent studio while contributing to the coherence of the whole.
-
-The meta-organvm organization is the umbrella layer: the vantage point from which the entire system becomes legible. It holds no application code. It exists to make the structure navigable and to demonstrate that creative work can be organized with the same rigor applied to distributed systems architecture.
+The eight-organ creative-institutional system — theory, art, commerce, orchestration, public process, community, marketing, and meta coordinated as a single portfolio.
 
 ## The Eight Organs
 
-| # | Greek Name | Domain | Organization | Repos | Status | Flagship |
-|:-:|:-----------|:-------|:-------------|------:|:-------|:---------|
-| I | **Theory** (θεωρία) | Theory | [organvm-i-theoria](https://github.com/organvm-i-theoria) | 26 | 1F / 21S / 1I | [recursive-engine--generative-entity](https://github.com/organvm-i-theoria/recursive-engine--generative-entity) |
-| II | **Art** (ποίησις) | Art | [organvm-ii-poiesis](https://github.com/organvm-ii-poiesis) | 32 | 2F / 25S / 1I | [metasystem-master](https://github.com/organvm-ii-poiesis/metasystem-master) |
-| III | **Commerce** (ἔργον) | Commerce | [organvm-iii-ergon](https://github.com/organvm-iii-ergon) | 32 | 2F / 26S / 1I | [public-record-data-scrapper](https://github.com/organvm-iii-ergon/public-record-data-scrapper) |
-| IV | **Orchestration** (τάξις) | Orchestration | [organvm-iv-taxis](https://github.com/organvm-iv-taxis) | 22 | 3F / 18S / 1I | [agentic-titan](https://github.com/organvm-iv-taxis/agentic-titan) |
-| V | **Public Process** (λόγος) | Public Process | [organvm-v-logos](https://github.com/organvm-v-logos) | 6 | 1F / 4S / 1I | [public-process](https://github.com/organvm-v-logos/public-process) |
-| VI | **Community** (κοινωνία) | Community | [organvm-vi-koinonia](https://github.com/organvm-vi-koinonia) | 6 | 1F / 4S / 1I | *Early development* |
-| VII | **Marketing** (κήρυγμα) | Marketing | [organvm-vii-kerygma](https://github.com/organvm-vii-kerygma) | 6 | 0F / 3S / 2I | *Early development* |
-| VIII | **Meta** (μετά (meta)) | Meta | [meta-organvm](https://github.com/meta-organvm) | 14 | 2F / 10S / 2I | *You are here* |
+| Organ | Domain | Organization |
+|-------|--------|-------------|
+| I | Theory | [organvm-i-theoria](https://github.com/organvm-i-theoria) |
+| II | Art | [organvm-ii-poiesis](https://github.com/organvm-ii-poiesis) |
+| III | Commerce | [organvm-iii-ergon](https://github.com/organvm-iii-ergon) |
+| IV | Orchestration | [organvm-iv-taxis](https://github.com/organvm-iv-taxis) |
+| V | Public Process | [organvm-v-logos](https://github.com/organvm-v-logos) |
+| VI | Community | [organvm-vi-koinonia](https://github.com/organvm-vi-koinonia) |
+| VII | Marketing | [organvm-vii-kerygma](https://github.com/organvm-vii-kerygma) |
+| VIII | Meta | [meta-organvm](https://github.com/meta-organvm) |
 
-<sub>Showcase counts are public repositories in the 8 core organs (sum 144). The 171 system total spans all 10 organizations — including Personal / Liminal, Process Sequence Governance (5 repos) — plus public forks. F = flagship, S = standard, I = infrastructure.</sub>
+## About
 
-## System Architecture
+This is the umbrella organization for the organvm system. Each organ operates as an independent GitHub organization with its own repositories, governance, and domain focus. Together, they form a coordinated creative-institutional infrastructure.
 
-The eight organs are not peers — they form a directed dependency graph with strict flow constraints.
+- **Theory** (I) produces the epistemological and ontological frameworks
+- **Art** (II) builds generative, interactive, and performance systems
+- **Commerce** (III) packages and deploys revenue-generating products
+- **Orchestration** (IV) governs cross-organ routing, promotion, and dependencies
+- **Public Process** (V) publishes essays, methodology, and thought leadership
+- **Community** (VI) manages collaborative spaces and member infrastructure
+- **Marketing** (VII) handles content distribution and audience building
+- **Meta** (VIII) provides the umbrella coordination layer
 
-**The creative pipeline flows in one direction:**
+## Get Started
 
-```
-Theory (I) → Art (II) → Commerce (III)
-```
-
-ORGAN-I produces epistemological frameworks, recursive models, and ontological scaffolding. ORGAN-II consumes those frameworks to build generative art systems, interactive performances, and experiential installations. ORGAN-III packages proven creative work into deployable, revenue-generating products — SaaS platforms, data tools, and browser extensions.
-
-**The governance layer operates orthogonally:**
-
-- **ORGAN-IV (Taxis)** manages cross-organ orchestration: dependency resolution, promotion state machines, and agentic routing infrastructure.
-- **ORGAN-V (Logos)** publishes the public process — essays and methodology documents that make the system's construction visible. [Read them here.](https://organvm-v-logos.github.io/public-process/)
-- **ORGAN-VI (Koinonia)** provides community infrastructure — reading groups, salon spaces, and collaborative forums.
-- **ORGAN-VII (Kerygma)** handles outbound distribution — POSSE syndication (Mastodon + Discord verified), announcements, and audience development.
-- **ORGAN-VIII (Meta)** is the umbrella coordination layer — the map of the territory.
-
-No back-edges exist in the dependency graph. Commerce cannot reach back into Art for runtime dependencies; Art cannot reach back into Theory. This constraint is architectural law, not suggestion. It ensures that each layer can evolve independently without creating circular coupling.
-
-## Design Principles
-
-**No back-edges.** The dependency graph flows strictly from theory through art to commerce. Governance organs (IV-VIII) coordinate laterally but never introduce circular dependencies.
-
-**Documentation precedes deployment.** No repository advances to its next phase until its documentation meets the defined quality gate. READMEs are written before features ship, not after.
-
-**Every README is a portfolio piece.** Documentation is written for grant reviewers, hiring managers, and collaborators — not just developers. Each README demonstrates both technical capability and communicative clarity.
-
-**Parallel launch across all organs.** The system launches as a whole, not organ by organ. Every organ is represented from day one, even if some begin as stubs. The architecture is legible at every stage.
-
-**Promotion is a state machine.** Repositories move through defined states with explicit criteria for each transition. No ad-hoc promotions.
-
-## System Scale
-
-**Per-organ repository coverage:**
-
-- **ORGAN-I (Theory):** 26 repositories — theory
-- **ORGAN-II (Art):** 32 repositories — art
-- **ORGAN-III (Commerce):** 32 repositories — commerce
-- **ORGAN-IV (Orchestration):** 22 repositories — orchestration
-- **ORGAN-V (Public Process):** 6 repositories — public process
-- **ORGAN-VI (Community):** 6 repositories — community
-- **ORGAN-VII (Marketing):** 6 repositories — marketing
-- **ORGAN-VIII (Meta):** 14 repositories — meta
-
-**System-wide:** 13 flagship · 112 standard · 12 infrastructure repositories across 10 organizations.
-
-## Selected Entry Points
-
-If you are exploring this system for the first time, start here:
-
-- **[recursive-engine--generative-entity](https://github.com/organvm-i-theoria/recursive-engine--generative-entity)** — The theoretical foundation. A recursive epistemological framework that demonstrates how self-referential systems can generate novel structure. Start here if you care about ideas.
-
-- **[metasystem-master](https://github.com/organvm-ii-poiesis/metasystem-master)** — The artistic expression. A metasystemic creative engine spanning generative music, interactive theatre, and experiential design. Start here if you care about making things.
-
-- **[public-record-data-scrapper](https://github.com/organvm-iii-ergon/public-record-data-scrapper)** — The commercial proof. A civic-tech data pipeline that scrapes, normalizes, and serves public records at scale. Start here if you care about shipping products.
-
-- **[agentic-titan](https://github.com/organvm-iv-taxis/agentic-titan)** — The orchestration layer. An agentic routing and governance system that coordinates work across the entire organ network. Start here if you care about systems architecture.
-
-- **[public-process](https://github.com/organvm-v-logos/public-process)** — The methodology. Essays and reflections on building creative infrastructure in public. Start here if you care about how and why this system exists. **[Read online →](https://organvm-v-logos.github.io/public-process/)**
-
-## Portfolio Context
-
-This system exists at the intersection of several disciplines that rarely meet:
-
-- **Systems architecture** — 10 organizations, 171 repositories, explicit dependency graphs, promotion state machines, and governance automation. The infrastructure demonstrates fluency with distributed systems thinking applied to creative production.
-
-- **Creative practice** — Generative art, interactive theatre, recursive epistemology, and metasystemic design. The work is not decorative; it is structurally integrated with the theoretical and commercial layers.
-
-- **Technical execution** — Data pipelines, browser extensions, SaaS platforms, agentic orchestration, and CI/CD automation. The commercial organ alone contains 32 repositories spanning multiple technology stacks.
-
-- **Documentation as craft** — Over 988K+ words of portfolio-grade documentation and 65 published essays, written to be read by humans, not just parsed by machines. Every README is a demonstration of communicative precision.
-
-The organvm system is a proof of concept for a specific thesis: that creative work, theoretical inquiry, and commercial execution can be coordinated within a single coherent architecture — and that the architecture itself can be made legible, navigable, and beautiful.
-
-## Author
-
-Built by [@4444j99](https://github.com/4444J99).
+Visit any organ organization above to explore its repositories, or see [organvm-iv-taxis](https://github.com/organvm-iv-taxis) for governance and system documentation.
 
 ---
 
-<div align="center">
-
-**meta-organvm** — eight organs, one system
-
-*Theory becomes art. Art becomes product. The whole becomes legible.*
-
-
-<sub>Metrics synced from the live registry · last refresh 2026-07-03. This profile is generated — every figure derives from repo-registry.json + system-metrics.json.</sub>
-
-</div>
+<sub>meta-organvm &mdash; eight organs, one system</sub>
 
 
 <!-- PORTFOLIO-HUB-START -->

--- a/profile/README.md
+++ b/profile/README.md
@@ -8,15 +8,15 @@ _System-wide registry, governance rules, and cross-organ coordination_
 
 **Eight organs. One system. Creative infrastructure at institutional scale.**
 
-[![Organ I — Theoria](https://img.shields.io/badge/I-Theoria-6A0DAD)](https://github.com/organvm-i-theoria)
-[![Organ II — Poiesis](https://img.shields.io/badge/II-Poiesis-DC143C)](https://github.com/organvm-ii-poiesis)
-[![Organ III — Ergon](https://img.shields.io/badge/III-Ergon-228B22)](https://github.com/organvm-iii-ergon)
-[![Organ IV — Taxis](https://img.shields.io/badge/IV-Taxis-FF8C00)](https://github.com/organvm-iv-taxis)
-[![Organ V — Logos](https://img.shields.io/badge/V-Logos-4169E1)](https://github.com/organvm-v-logos)
-[![Organ VI — Koinonia](https://img.shields.io/badge/VI-Koinonia-20B2AA)](https://github.com/organvm-vi-koinonia)
-[![Organ VII — Kerygma](https://img.shields.io/badge/VII-Kerygma-FF1493)](https://github.com/organvm-vii-kerygma)
+[![Organ I — Theory](https://img.shields.io/badge/I-Theory-6A0DAD)](https://github.com/organvm-i-theoria)
+[![Organ II — Art](https://img.shields.io/badge/II-Art-DC143C)](https://github.com/organvm-ii-poiesis)
+[![Organ III — Commerce](https://img.shields.io/badge/III-Commerce-228B22)](https://github.com/organvm-iii-ergon)
+[![Organ IV — Orchestration](https://img.shields.io/badge/IV-Orchestration-FF8C00)](https://github.com/organvm-iv-taxis)
+[![Organ V — Public Process](https://img.shields.io/badge/V-Public%20Process-4169E1)](https://github.com/organvm-v-logos)
+[![Organ VI — Community](https://img.shields.io/badge/VI-Community-20B2AA)](https://github.com/organvm-vi-koinonia)
+[![Organ VII — Marketing](https://img.shields.io/badge/VII-Marketing-FF1493)](https://github.com/organvm-vii-kerygma)
 
-**<!-- v:total_repos -->113<!-- /v --> repositories &bull; <!-- v:total_words_short -->404K+<!-- /v --> words of documentation &bull; <!-- v:total_organs -->8<!-- /v --> GitHub organizations &bull; <!-- v:published_essays -->16<!-- /v --> published essays**
+**171 repositories &bull; 988K+ words of documentation &bull; 10 GitHub organizations &bull; 65 published essays**
 
 **[Read the essays →](https://organvm-v-logos.github.io/public-process/)**
 
@@ -26,7 +26,7 @@ _System-wide registry, governance rules, and cross-organ coordination_
 
 ## System Overview
 
-The organvm system is a creative-institutional infrastructure composed of eight specialized organs — each operating as an independent GitHub organization with its own repositories, governance model, and domain focus. Together, they form a coordinated portfolio that spans epistemological theory, generative art, commercial products, orchestration tooling, public scholarship, community spaces, and content distribution.
+The organvm system is a creative-institutional infrastructure composed of eight specialized organs — each operating as an independent GitHub organization with its own repositories, governance model, and domain focus. Together they span epistemological theory, generative art, commercial products, orchestration tooling, public scholarship, community spaces, and content distribution — realized across 10 GitHub organizations.
 
 This is not a monorepo. It is not a corporate org chart. It is an organism — a living system where theory feeds art, art feeds commerce, and the whole is governed by explicit dependency rules that prevent architectural decay. Each organ has a Greek name drawn from its domain's philosophical lineage, and each operates with the autonomy of an independent studio while contributing to the coherence of the whole.
 
@@ -34,20 +34,18 @@ The meta-organvm organization is the umbrella layer: the vantage point from whic
 
 ## The Eight Organs
 
-| # | Greek Name | Domain | Organization | Repos | Status Distribution | Flagship |
-|:-:|:-----------|:-------|:-------------|------:|:--------------------|:---------|
-| I | **Theoria** (θεωρία) | Theory | [organvm-i-theoria](https://github.com/organvm-i-theoria) | 18 | 9P / 4Pr / 3S / 2D | [recursive-engine--generative-entity](https://github.com/organvm-i-theoria/recursive-engine--generative-entity) |
-| II | **Poiesis** (ποίησις) | Art | [organvm-ii-poiesis](https://github.com/organvm-ii-poiesis) | 21 | 4P / 5Pr / 7S / 5D | [metasystem-master](https://github.com/organvm-ii-poiesis/metasystem-master) |
-| III | **Ergon** (ἔργον) | Commerce | [organvm-iii-ergon](https://github.com/organvm-iii-ergon) | 22 | 15P / 3Pr / 3S / 1D | [public-record-data-scrapper](https://github.com/organvm-iii-ergon/public-record-data-scrapper) |
-| IV | **Taxis** (τάξις) | Orchestration | [organvm-iv-taxis](https://github.com/organvm-iv-taxis) | 9 | 3P / 2Pr / 1S / 3D | [agentic-titan](https://github.com/organvm-iv-taxis/agentic-titan) |
-| V | **Logos** (λόγος) | Public Process | [organvm-v-logos](https://github.com/organvm-v-logos) | 2 | 1P / 1D | [public-process](https://github.com/organvm-v-logos/public-process) |
-| VI | **Koinonia** (κοινωνία) | Community | [organvm-vi-koinonia](https://github.com/organvm-vi-koinonia) | 3 | 2S / 1D | *Early development* |
-| VII | **Kerygma** (κήρυγμα) | Marketing | [organvm-vii-kerygma](https://github.com/organvm-vii-kerygma) | 4 | 3S / 1D | *Early development* |
-| VIII | **Meta** (μετά) | Umbrella | [meta-organvm](https://github.com/meta-organvm) | 2 | 1P / 1D | *You are here* |
+| # | Greek Name | Domain | Organization | Repos | Status | Flagship |
+|:-:|:-----------|:-------|:-------------|------:|:-------|:---------|
+| I | **Theory** (θεωρία) | Theory | [organvm-i-theoria](https://github.com/organvm-i-theoria) | 26 | 1F / 21S / 1I | [recursive-engine--generative-entity](https://github.com/organvm-i-theoria/recursive-engine--generative-entity) |
+| II | **Art** (ποίησις) | Art | [organvm-ii-poiesis](https://github.com/organvm-ii-poiesis) | 32 | 2F / 25S / 1I | [metasystem-master](https://github.com/organvm-ii-poiesis/metasystem-master) |
+| III | **Commerce** (ἔργον) | Commerce | [organvm-iii-ergon](https://github.com/organvm-iii-ergon) | 32 | 2F / 26S / 1I | [public-record-data-scrapper](https://github.com/organvm-iii-ergon/public-record-data-scrapper) |
+| IV | **Orchestration** (τάξις) | Orchestration | [organvm-iv-taxis](https://github.com/organvm-iv-taxis) | 22 | 3F / 18S / 1I | [agentic-titan](https://github.com/organvm-iv-taxis/agentic-titan) |
+| V | **Public Process** (λόγος) | Public Process | [organvm-v-logos](https://github.com/organvm-v-logos) | 6 | 1F / 4S / 1I | [public-process](https://github.com/organvm-v-logos/public-process) |
+| VI | **Community** (κοινωνία) | Community | [organvm-vi-koinonia](https://github.com/organvm-vi-koinonia) | 6 | 1F / 4S / 1I | *Early development* |
+| VII | **Marketing** (κήρυγμα) | Marketing | [organvm-vii-kerygma](https://github.com/organvm-vii-kerygma) | 6 | 0F / 3S / 2I | *Early development* |
+| VIII | **Meta** (μετά (meta)) | Meta | [meta-organvm](https://github.com/meta-organvm) | 14 | 2F / 10S / 2I | *You are here* |
 
-<sub>P = PRODUCTION, Pr = PROTOTYPE, S = SKELETON, D = DESIGN_ONLY</sub>
-
-**System-wide:** 33 PRODUCTION · 14 PROTOTYPE · 19 SKELETON · 15 DESIGN_ONLY
+<sub>Showcase counts are public repositories in the 8 core organs (sum 144). The 171 system total spans all 10 organizations — including Personal / Liminal, Process Sequence Governance (5 repos) — plus public forks. F = flagship, S = standard, I = infrastructure.</sub>
 
 ## System Architecture
 
@@ -64,7 +62,7 @@ ORGAN-I produces epistemological frameworks, recursive models, and ontological s
 **The governance layer operates orthogonally:**
 
 - **ORGAN-IV (Taxis)** manages cross-organ orchestration: dependency resolution, promotion state machines, and agentic routing infrastructure.
-- **ORGAN-V (Logos)** publishes the public process — 16 essays and methodology documents that make the system's construction visible. [Read them here.](https://organvm-v-logos.github.io/public-process/)
+- **ORGAN-V (Logos)** publishes the public process — essays and methodology documents that make the system's construction visible. [Read them here.](https://organvm-v-logos.github.io/public-process/)
 - **ORGAN-VI (Koinonia)** provides community infrastructure — reading groups, salon spaces, and collaborative forums.
 - **ORGAN-VII (Kerygma)** handles outbound distribution — POSSE syndication (Mastodon + Discord verified), announcements, and audience development.
 - **ORGAN-VIII (Meta)** is the umbrella coordination layer — the map of the territory.
@@ -81,34 +79,22 @@ No back-edges exist in the dependency graph. Commerce cannot reach back into Art
 
 **Parallel launch across all organs.** The system launches as a whole, not organ by organ. Every organ is represented from day one, even if some begin as stubs. The architecture is legible at every stage.
 
-**Promotion is a state machine.** Repositories move through defined states — LOCAL, CANDIDATE, PUBLIC_PROCESS, GRADUATED, ARCHIVED — with explicit criteria for each transition. No ad-hoc promotions.
+**Promotion is a state machine.** Repositories move through defined states with explicit criteria for each transition. No ad-hoc promotions.
 
-## Current Status
+## System Scale
 
-**CONSOLIDATION-II Sprint (2026-02-12)** — System launched 2026-02-11. All 8 organs OPERATIONAL.
+**Per-organ repository coverage:**
 
-| Metric | Value |
-|--------|------:|
-| Total repositories | <!-- v:total_repos -->113<!-- /v --> |
-| Total documentation | <!-- v:total_words_short -->404K+<!-- /v --> words |
-| Organ organizations live | 8 of 8 |
-| Profile READMEs deployed | 8 of 8 |
-| Published essays | 16 |
-| PRODUCTION repos | 33 |
-| PROTOTYPE repos | 14 |
-| SKELETON repos | 19 |
-| DESIGN_ONLY repos | 15 |
+- **ORGAN-I (Theory):** 26 repositories — theory
+- **ORGAN-II (Art):** 32 repositories — art
+- **ORGAN-III (Commerce):** 32 repositories — commerce
+- **ORGAN-IV (Orchestration):** 22 repositories — orchestration
+- **ORGAN-V (Public Process):** 6 repositories — public process
+- **ORGAN-VI (Community):** 6 repositories — community
+- **ORGAN-VII (Marketing):** 6 repositories — marketing
+- **ORGAN-VIII (Meta):** 14 repositories — meta
 
-**Per-organ documentation coverage:**
-
-- **ORGAN-I (Theoria):** 18 repos, ~56,000 words — epistemological frameworks, recursive engines, ontological models
-- **ORGAN-II (Poiesis):** 21 repos, ~46,000 words — generative art, interactive performance, metasystem architecture
-- **ORGAN-III (Ergon):** 22 repos, ~74,000 words — SaaS products, data scrapers, browser extensions, civic tech
-- **ORGAN-IV (Taxis):** 9 repos, ~18,000 words — agentic orchestration, governance routing, system coordination
-- **ORGAN-V (Logos):** 2 repos, 16 essays — public process essays and methodology
-- **ORGAN-VI (Koinonia):** 3 repos — community infrastructure in early development
-- **ORGAN-VII (Kerygma):** 4 repos — distribution systems with POSSE pipeline
-- **ORGAN-VIII (Meta):** 2 repos — umbrella coordination and corpus testament
+**System-wide:** 13 flagship · 112 standard · 12 infrastructure repositories across 10 organizations.
 
 ## Selected Entry Points
 
@@ -122,19 +108,19 @@ If you are exploring this system for the first time, start here:
 
 - **[agentic-titan](https://github.com/organvm-iv-taxis/agentic-titan)** — The orchestration layer. An agentic routing and governance system that coordinates work across the entire organ network. Start here if you care about systems architecture.
 
-- **[public-process](https://github.com/organvm-v-logos/public-process)** — The methodology. 16 essays and reflections on building creative infrastructure in public. Start here if you care about how and why this system exists. **[Read online →](https://organvm-v-logos.github.io/public-process/)**
+- **[public-process](https://github.com/organvm-v-logos/public-process)** — The methodology. Essays and reflections on building creative infrastructure in public. Start here if you care about how and why this system exists. **[Read online →](https://organvm-v-logos.github.io/public-process/)**
 
 ## Portfolio Context
 
 This system exists at the intersection of several disciplines that rarely meet:
 
-- **Systems architecture** — Eight organizations, <!-- v:total_repos -->113<!-- /v --> repositories, explicit dependency graphs, promotion state machines, and governance automation. The infrastructure demonstrates fluency with distributed systems thinking applied to creative production.
+- **Systems architecture** — 10 organizations, 171 repositories, explicit dependency graphs, promotion state machines, and governance automation. The infrastructure demonstrates fluency with distributed systems thinking applied to creative production.
 
 - **Creative practice** — Generative art, interactive theatre, recursive epistemology, and metasystemic design. The work is not decorative; it is structurally integrated with the theoretical and commercial layers.
 
-- **Technical execution** — Data pipelines, browser extensions, SaaS platforms, agentic orchestration, and CI/CD automation. The commercial organ alone contains 22 repositories spanning multiple technology stacks.
+- **Technical execution** — Data pipelines, browser extensions, SaaS platforms, agentic orchestration, and CI/CD automation. The commercial organ alone contains 32 repositories spanning multiple technology stacks.
 
-- **Documentation as craft** — Over <!-- v:total_words_short -->404K+<!-- /v --> words of portfolio-grade documentation and <!-- v:published_essays -->16<!-- /v --> published essays, written to be read by humans, not just parsed by machines. Every README is a demonstration of communicative precision.
+- **Documentation as craft** — Over 988K+ words of portfolio-grade documentation and 65 published essays, written to be read by humans, not just parsed by machines. Every README is a demonstration of communicative precision.
 
 The organvm system is a proof of concept for a specific thesis: that creative work, theoretical inquiry, and commercial execution can be coordinated within a single coherent architecture — and that the architecture itself can be made legible, navigable, and beautiful.
 
@@ -150,9 +136,11 @@ Built by [@4444j99](https://github.com/4444J99).
 
 *Theory becomes art. Art becomes product. The whole becomes legible.*
 
-*CONSOLIDATION-II Sprint 2026-02-12*
+
+<sub>Metrics synced from the live registry · last refresh 2026-07-03. This profile is generated — every figure derives from repo-registry.json + system-metrics.json.</sub>
 
 </div>
+
 
 <!-- PORTFOLIO-HUB-START -->
 ---

--- a/scripts/refresh-profile.py
+++ b/scripts/refresh-profile.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Pull the meta-org profile README from the corpus that OWNS its data.
+
+This org profile is a *projection*, not a hand-kept document. The corpus
+(organvm-corpvs-testamentvm) renders it from the organs that own the truth —
+config (the organ showcase), repo-registry.json (per-organ counts), and
+system-metrics.json/system-snapshot.json (live totals) — and commits the result
+to .github-template/generated/meta-organvm.profile-README.md.
+
+This script fetches that rendered projection and writes it to profile/README.md.
+Pull model: no cross-org token, mirroring how the portfolio fetches the corpus's
+system-metrics.json at build time. Nothing here decides framing or pins a number
+— every figure is whatever the corpus published.
+
+The one thing we PRESERVE is the <!-- PORTFOLIO-HUB-START -->..<!-- ..-END -->
+block: it is injected and owned by a different organ (the portfolio-hub tool),
+so we re-attach it rather than clobber it.
+
+Usage:
+    python3 scripts/refresh-profile.py            # write profile/README.md if changed
+    python3 scripts/refresh-profile.py --check    # exit 1 if it would change (CI drift gate)
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PROFILE_PATH = ROOT / "profile" / "README.md"
+SOURCE_URL = (
+    "https://raw.githubusercontent.com/organvm/organvm-corpvs-testamentvm/"
+    "main/.github-template/generated/meta-organvm.profile-README.md"
+)
+HUB_START = "<!-- PORTFOLIO-HUB-START -->"
+HUB_END = "<!-- PORTFOLIO-HUB-END -->"
+
+
+def fetch(url: str) -> str:
+    req = urllib.request.Request(url, headers={"User-Agent": "organvm-profile-refresh"})
+    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310 (fixed trusted URL)
+        return resp.read().decode("utf-8")
+
+
+def preserved_hub_block(existing: str) -> str:
+    """Return the portfolio-hub block (owned by another organ) to re-attach, or ''."""
+    if HUB_START in existing and HUB_END in existing:
+        start = existing.index(HUB_START)
+        end = existing.index(HUB_END) + len(HUB_END)
+        return "\n\n" + existing[start:end].strip() + "\n"
+    return ""
+
+
+def compose(projection: str, existing: str) -> str:
+    body = projection.rstrip("\n")
+    hub = preserved_hub_block(existing)
+    return body + ("\n" + hub if hub else "\n")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Pull the projected meta-org profile from the corpus.")
+    ap.add_argument("--check", action="store_true", help="Exit 1 if profile/README.md is out of date")
+    ap.add_argument("--source", default=SOURCE_URL, help="Override the projection source URL")
+    args = ap.parse_args()
+
+    try:
+        projection = fetch(args.source)
+    except Exception as exc:  # network/transient — never wedge the beat
+        print(f"WARNING: could not fetch projection ({exc}); leaving profile unchanged", file=sys.stderr)
+        return 0
+
+    if not projection.strip() or "# meta-" not in projection:
+        print("WARNING: projection looks empty/invalid; leaving profile unchanged", file=sys.stderr)
+        return 0
+
+    existing = PROFILE_PATH.read_text() if PROFILE_PATH.exists() else ""
+    desired = compose(projection, existing)
+
+    if existing == desired:
+        print("ok: profile/README.md already matches the corpus projection")
+        return 0
+
+    if args.check:
+        print("DRIFT: profile/README.md is out of date — run scripts/refresh-profile.py", file=sys.stderr)
+        return 1
+
+    PROFILE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    PROFILE_PATH.write_text(desired)
+    print(f"Updated profile/README.md from corpus projection ({len(desired.split())} words)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

`github.com/organvm` showed a frozen snapshot — **113 repos / 404K words / "8 organizations"**, a per-organ table summing to **81**, and three essay counts (16/49/65) on one page — while live the system is **171 repos / 988K words / 10 orgs**.

## Fix — pull the projection, don't hand-edit

The corpus (`organvm-corpvs-testamentvm`, PR #529) now renders this profile from the organs that **own** the truth (config showcase + `repo-registry.json` + `system-metrics.json` + `system-snapshot.json`). This repo just pulls the result:

- `scripts/refresh-profile.py` — fetches the corpus-rendered projection, writes `profile/README.md`, **preserves** the `<!-- PORTFOLIO-HUB -->` block (owned by a different organ). Pull model, no cross-org token. `--check` gates drift.
- `.github/workflows/refresh-profile.yml` — daily (06:30 UTC, just after the corpus metrics beat) + dispatch.

This commit carries the first projected result: **171 repos · 988K+ words · 10 GitHub organizations · 65 published essays**, per-organ table derived, footnote reconciling the 144 showcase sum vs the 171 total.

> Depends on organvm/organvm-corpvs-testamentvm#529 (the projection source). Merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)