### PR TITLE
fix(stale): never auto-close — label only (days-before-close: -1)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,16 +15,22 @@ jobs:
     steps:
       - uses: actions/stale@v10
         with:
+          # This universe NEVER auto-closes. "If it was ever asked for it was
+          # wanted" — every issue/PR is preserved and evolved, never closed or
+          # dismissed. The stale label is an INFORMATIONAL signal only.
           stale-issue-message: >
-            This issue has been automatically marked as stale because it has not
-            had recent activity. It will be closed in 14 days if no further
-            activity occurs.
+            This issue has been automatically labeled `stale` after 60 days
+            without activity. This is an informational signal only — it will
+            **not** be closed. This project never auto-closes issues; every
+            request is preserved and evolved toward its higher form. Comment or
+            remove the label to clear it.
           stale-pr-message: >
-            This PR has been automatically marked as stale because it has not
-            had recent activity. It will be closed in 14 days if no further
-            activity occurs.
+            This PR has been automatically labeled `stale` after 60 days without
+            activity. This is an informational signal only — it will **not** be
+            closed. Rebase, comment, or remove the label to clear it.
           days-before-stale: 60
-          days-before-close: 14
+          # -1 disables the close step entirely: label, never close.
+          days-before-close: -1
           exempt-issue-labels: 'pinned,evergreen,omega,blocked'
           exempt-pr-labels: 'pinned,evergreen,work-in-progress'
           stale-issue-label: 'stale'


### PR DESCRIPTION
## Never auto-close — the stale workflow now labels only

The org-default `stale.yml` set **`days-before-close: 14`**, which auto-closes any issue or PR 14 days after it's marked stale (60 days inactivity → `stale` → closed 14 days later).

That directly violates this universe's **absolute standing doctrine**: we never close, dismiss, or delete an issue or PR. *"If it was ever asked for it was wanted"* — every request is preserved and evolved toward its higher form.

### Change
- **`days-before-close: 14` → `-1`** — `actions/stale` treats `-1` as "never close"; the close step is disabled entirely.
- Kept `days-before-stale: 60` — the informational `stale` label is still applied (a harmless activity signal), it just never leads to a close.
- Rewrote the stale messages so they state the label is informational and nothing will be closed.

### Scope
This is the **org-default** community-health workflow — it applies to every `organvm` repo that doesn't ship its own `stale.yml`. The ~45 per-repo copies (byte-identical propagations of the old config) are being neutralized in a companion sweep so no repo anywhere auto-closes.

Reversible, single-file, no behavior beyond labeling. Safe to merge.
